### PR TITLE
ext-java-code-quality to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 0.0.7
 - name: ext-java-code-quality
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9


### PR DESCRIPTION
Promote ext-java-code-quality to version 0.0.9